### PR TITLE
fix: #4 use configured score_range in display instead of hardcoded /10

### DIFF
--- a/promptlab/application/run_experiment.py
+++ b/promptlab/application/run_experiment.py
@@ -124,6 +124,7 @@ class RunExperiment:
             duration_seconds=round(duration, 2),
             cached_responses=cached_count,
             hypothesis=config.experiment.hypothesis,
+            score_range=config.judge.score_range,
             results=results_list,
             stats=stats,
         )

--- a/promptlab/domain/contracts/results.py
+++ b/promptlab/domain/contracts/results.py
@@ -42,6 +42,7 @@ class RunSummary:
     duration_seconds: float
     cached_responses: int
     hypothesis: str = ""
+    score_range: tuple[int, int] = (1, 10)
     results: list[RunResult] = field(default_factory=list)
     stats: list[InputStats] = field(default_factory=list)
 

--- a/promptlab/infrastructure/console_display.py
+++ b/promptlab/infrastructure/console_display.py
@@ -59,14 +59,15 @@ def _display_individual_results_table(
     table.add_column("Tokens", justify="right")
     table.add_column("Cached", justify="center")
 
+    score_max = summary.score_range[1]
     for result in summary.results:
         score = result.judge["score"]
-        score_style = _score_style(score)
+        score_style = _score_style(score, summary.score_range)
 
         table.add_row(
             result.input_id,
             result.model,
-            Text(f"{score}/10", style=score_style),
+            Text(f"{score}/{score_max}", style=score_style),
             f"{result.latency_ms}ms",
             f"{result.input_tokens + result.output_tokens}",
             "[green]Yes[/green]" if result.cached else "[dim]No[/dim]",
@@ -80,7 +81,7 @@ def _display_individual_results_table(
 
     console.print(
         f"[dim]Duration: {summary.duration_seconds}s | "
-        f"Avg Score: {avg_score:.1f}/10 | "
+        f"Avg Score: {avg_score:.1f}/{score_max} | "
         f"Avg Latency: {avg_latency:.0f}ms | "
         f"Cached: {summary.cached_responses}/{len(summary.results)}[/dim]"
     )
@@ -107,7 +108,7 @@ def _display_stats_table(summary: RunSummary, show_hypothesis: bool = True) -> N
     table.add_column("Scores", justify="left")
 
     for stat in summary.stats:
-        score_style = _score_style(stat.mean)
+        score_style = _score_style(stat.mean, summary.score_range)
 
         mean_display = f"{stat.mean:.1f}"
         ci_display = f"({stat.ci_lower:.1f}-{stat.ci_upper:.1f})"
@@ -141,7 +142,7 @@ def _display_stats_table(summary: RunSummary, show_hypothesis: bool = True) -> N
 
     console.print(
         f"[dim]Duration: {summary.duration_seconds}s | "
-        f"Overall Mean: {overall_mean:.1f}/10 | "
+        f"Overall Mean: {overall_mean:.1f}/{summary.score_range[1]} | "
         f"Avg Latency: {avg_latency:.0f}ms | "
         f"Total Runs: {len(summary.results)}[/dim]"
     )
@@ -196,7 +197,7 @@ def display_compare_table(experiment_path: Path) -> None:
             avg_latency = sum(r.latency_ms for r in summary.results) / len(
                 summary.results
             )
-            score_style = _score_style(avg_score)
+            score_style = _score_style(avg_score, summary.score_range)
 
             runs_info = f"{len(summary.results)}"
             if summary.runs_per_input > 1:
@@ -204,7 +205,7 @@ def display_compare_table(experiment_path: Path) -> None:
 
             table.add_row(
                 variant_path.name,
-                Text(f"{avg_score:.1f}/10", style=score_style),
+                Text(f"{avg_score:.1f}/{summary.score_range[1]}", style=score_style),
                 f"[dim]{ci_display}[/dim]",
                 f"{avg_latency:.0f}ms",
                 runs_info,
@@ -268,10 +269,12 @@ def display_response(
         return
 
     for result in results:
-        _display_single_response(result)
+        _display_single_response(result, summary.score_range)
 
 
-def _display_single_response(result: RunResult) -> None:
+def _display_single_response(
+    result: RunResult, score_range: tuple[int, int] = (1, 10)
+) -> None:
     content = []
 
     content.append("[bold cyan]RESPONSE[/bold cyan]")
@@ -295,8 +298,8 @@ def _display_single_response(result: RunResult) -> None:
     content.append("[bold cyan]JUDGE[/bold cyan]")
     content.append("[dim]─────[/dim]")
     score = result.judge["score"]
-    score_style = _score_style(score)
-    content.append(f"Score: [{score_style}]{score}/10[/{score_style}]")
+    score_style = _score_style(score, score_range)
+    content.append(f"Score: [{score_style}]{score}/{score_range[1]}[/{score_style}]")
     reasoning = result.judge.get("reasoning", "")
     if reasoning:
         content.append(f"Reasoning: {reasoning}")
@@ -352,12 +355,14 @@ def display_run_complete(summary: RunSummary, show_hypothesis: bool = True) -> N
     display_results_table(summary, show_hypothesis)
 
 
-def _score_style(score: float) -> str:
-    if score >= 8:
+def _score_style(score: float, score_range: tuple[int, int] = (1, 10)) -> str:
+    score_min, score_max = score_range
+    range_size = score_max - score_min
+    if score >= score_min + range_size * 0.8:
         return "bold green"
-    elif score >= 6:
+    elif score >= score_min + range_size * 0.6:
         return "yellow"
-    elif score >= 4:
+    elif score >= score_min + range_size * 0.4:
         return "orange3"
     else:
         return "bold red"

--- a/promptlab/infrastructure/file_result_repository.py
+++ b/promptlab/infrastructure/file_result_repository.py
@@ -31,6 +31,7 @@ class FileResultRepository(ResultRepositoryContract):
             "runs_per_input": summary.runs_per_input,
             "duration_seconds": summary.duration_seconds,
             "cached_responses": summary.cached_responses,
+            "score_range": list(summary.score_range),
         }
 
         with open(results_dir / "run.yaml", "w") as f:
@@ -98,6 +99,7 @@ class FileResultRepository(ResultRepositoryContract):
             runs_per_input=meta.get("runs_per_input", 1),
             duration_seconds=meta["duration_seconds"],
             cached_responses=meta["cached_responses"],
+            score_range=tuple(meta.get("score_range", [1, 10])),
             results=results,
             stats=stats,
         )

--- a/tests/test_console_display.py
+++ b/tests/test_console_display.py
@@ -1,0 +1,112 @@
+from io import StringIO
+from unittest.mock import patch
+
+from rich.console import Console
+
+from promptlab.domain.contracts.results import RunResult, RunSummary
+from promptlab.infrastructure.console_display import (
+    _display_individual_results_table,
+    _score_style,
+)
+
+
+# --- _score_style ---
+
+
+def test_score_style_default_range_green():
+    # range_size=9; green >= 1+7.2=8.2, so 9 and 10 are green
+    assert _score_style(9, (1, 10)) == "bold green"
+    assert _score_style(10, (1, 10)) == "bold green"
+
+
+def test_score_style_default_range_yellow():
+    # yellow >= 1+5.4=6.4, so 7 and 8 are yellow
+    assert _score_style(7, (1, 10)) == "yellow"
+    assert _score_style(8, (1, 10)) == "yellow"
+
+
+def test_score_style_default_range_orange():
+    # orange >= 1+3.6=4.6, so 5 and 6 are orange
+    assert _score_style(5, (1, 10)) == "orange3"
+    assert _score_style(6, (1, 10)) == "orange3"
+
+
+def test_score_style_default_range_red():
+    # below 4.6, so 1-4 are red
+    assert _score_style(1, (1, 10)) == "bold red"
+    assert _score_style(4, (1, 10)) == "bold red"
+
+
+def test_score_style_range_1_5():
+    # range_size = 4; thresholds: green >= 1+3.2=4.2, yellow >= 1+2.4=3.4, orange >= 1+1.6=2.6
+    assert _score_style(5, (1, 5)) == "bold green"
+    assert _score_style(4, (1, 5)) == "yellow"
+    assert _score_style(3, (1, 5)) == "orange3"
+    assert _score_style(1, (1, 5)) == "bold red"
+
+
+def test_score_style_range_1_20():
+    # range_size = 19; thresholds: green >= 1+15.2=16.2, yellow >= 1+11.4=12.4, orange >= 1+7.6=8.6
+    assert _score_style(17, (1, 20)) == "bold green"
+    assert _score_style(13, (1, 20)) == "yellow"
+    assert _score_style(9, (1, 20)) == "orange3"
+    assert _score_style(5, (1, 20)) == "bold red"
+
+
+# --- _display_individual_results_table ---
+
+
+def _make_result(score: int) -> RunResult:
+    return RunResult(
+        input_id="test-input",
+        model="test:model",
+        run_number=1,
+        cached=False,
+        latency_ms=100,
+        input_tokens=10,
+        output_tokens=20,
+        response={"content": "test"},
+        judge={"score": score},
+    )
+
+
+def _make_summary(score_range: tuple[int, int], results: list[RunResult]) -> RunSummary:
+    return RunSummary(
+        timestamp="20240101_120000",
+        experiment="test-exp",
+        variant="v1",
+        models=["test:model"],
+        inputs_count=len(results),
+        runs_per_input=1,
+        duration_seconds=1.0,
+        cached_responses=0,
+        score_range=score_range,
+        results=results,
+    )
+
+
+def test_individual_results_table_shows_correct_score_max():
+    buf = StringIO()
+    test_console = Console(file=buf, highlight=False, markup=False)
+
+    summary = _make_summary((1, 5), [_make_result(4)])
+
+    with patch("promptlab.infrastructure.console_display.console", test_console):
+        _display_individual_results_table(summary, show_hypothesis=False)
+
+    output = buf.getvalue()
+    assert "/5" in output
+    assert "/10" not in output
+
+
+def test_individual_results_table_default_range_shows_10():
+    buf = StringIO()
+    test_console = Console(file=buf, highlight=False, markup=False)
+
+    summary = _make_summary((1, 10), [_make_result(8)])
+
+    with patch("promptlab.infrastructure.console_display.console", test_console):
+        _display_individual_results_table(summary, show_hypothesis=False)
+
+    output = buf.getvalue()
+    assert "/10" in output


### PR DESCRIPTION
The score display always showed /10 regardless of the judge's score_range setting. Thread score_range through RunSummary and persist it in run.yaml so all display functions use the configured max value.