### PR TITLE
refactor(tests): adopt test_subject_should_expectation naming convention

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,7 +12,7 @@ def cache(tmp_path: Path) -> Generator[FileCache, None, None]:
     yield FileCache(tmp_path / ".cache")
 
 
-def test_make_key_is_deterministic(cache: FileCache):
+def test_make_key_should_be_deterministic(cache: FileCache):
     key1 = cache.make_key(
         prompt="Hello {name}",
         input_data={"name": "World"},
@@ -27,7 +27,7 @@ def test_make_key_is_deterministic(cache: FileCache):
     assert key1 == key2
 
 
-def test_make_key_differs_for_different_inputs(cache: FileCache):
+def test_make_key_should_differ_when_different_inputs(cache: FileCache):
     key1 = cache.make_key(
         prompt="Hello {name}",
         input_data={"name": "World"},
@@ -42,7 +42,7 @@ def test_make_key_differs_for_different_inputs(cache: FileCache):
     assert key1 != key2
 
 
-def test_put_and_get(cache: FileCache):
+def test_cache_should_store_and_retrieve_response(cache: FileCache):
     key = cache.make_key(
         prompt="test",
         input_data={},
@@ -66,12 +66,12 @@ def test_put_and_get(cache: FileCache):
     assert retrieved.input_tokens == 10
 
 
-def test_get_returns_none_for_missing_key(cache: FileCache):
+def test_cache_should_return_none_when_key_missing(cache: FileCache):
     result = cache.get("nonexistent")
     assert result is None
 
 
-def test_clear_removes_all_entries(cache: FileCache):
+def test_cache_should_remove_all_entries_when_cleared(cache: FileCache):
     key = cache.make_key(prompt="test", input_data={}, model="test")
     response = ProviderResponse(content="test")
     cache.put(key, response)

--- a/tests/test_cli_key_refs.py
+++ b/tests/test_cli_key_refs.py
@@ -5,14 +5,14 @@ from promptlab.cli import app
 runner = CliRunner()
 
 
-def test_key_ref_invalid_format_no_colon(tmp_path):
+def test_key_ref_should_fail_when_no_colon(tmp_path):
     result = runner.invoke(app, ["run", str(tmp_path), "--key-ref", "INVALID_FORMAT"])
 
     assert result.exit_code == 1
     assert "Invalid --key-ref format" in result.output
 
 
-def test_key_ref_unknown_provider(tmp_path):
+def test_key_ref_should_fail_when_unknown_provider(tmp_path):
     result = runner.invoke(app, ["run", str(tmp_path), "--key-ref", "gemini:MY_KEY"])
 
     assert result.exit_code == 1
@@ -20,14 +20,14 @@ def test_key_ref_unknown_provider(tmp_path):
     assert "gemini" in result.output
 
 
-def test_key_ref_unknown_provider_shows_available(tmp_path):
+def test_key_ref_should_show_available_providers_when_unknown(tmp_path):
     result = runner.invoke(app, ["run", str(tmp_path), "--key-ref", "gemini:MY_KEY"])
 
     assert "openai" in result.output
     assert "anthropic" in result.output
 
 
-def test_key_ref_multiple_refs_parsed(tmp_path):
+def test_key_ref_should_parse_multiple_refs(tmp_path):
     """Multiple --key-ref flags are accepted without parsing errors."""
     result = runner.invoke(
         app,
@@ -45,7 +45,7 @@ def test_key_ref_multiple_refs_parsed(tmp_path):
     assert "Unknown provider" not in result.output
 
 
-def test_key_ref_short_flag(tmp_path):
+def test_key_ref_should_work_when_short_flag(tmp_path):
     """The -k short flag works the same as --key-ref."""
     result = runner.invoke(app, ["run", str(tmp_path), "-k", "openai:MY_KEY"])
 

--- a/tests/test_console_display.py
+++ b/tests/test_console_display.py
@@ -13,31 +13,31 @@ from promptlab.infrastructure.console_display import (
 # --- _score_style ---
 
 
-def test_score_style_default_range_green():
+def test_score_style_should_be_green_when_default_range_high():
     # range_size=9; green >= 1+7.2=8.2, so 9 and 10 are green
     assert _score_style(9, (1, 10)) == "bold green"
     assert _score_style(10, (1, 10)) == "bold green"
 
 
-def test_score_style_default_range_yellow():
+def test_score_style_should_be_yellow_when_default_range_mid():
     # yellow >= 1+5.4=6.4, so 7 and 8 are yellow
     assert _score_style(7, (1, 10)) == "yellow"
     assert _score_style(8, (1, 10)) == "yellow"
 
 
-def test_score_style_default_range_orange():
+def test_score_style_should_be_orange_when_default_range_low():
     # orange >= 1+3.6=4.6, so 5 and 6 are orange
     assert _score_style(5, (1, 10)) == "orange3"
     assert _score_style(6, (1, 10)) == "orange3"
 
 
-def test_score_style_default_range_red():
+def test_score_style_should_be_red_when_default_range_lowest():
     # below 4.6, so 1-4 are red
     assert _score_style(1, (1, 10)) == "bold red"
     assert _score_style(4, (1, 10)) == "bold red"
 
 
-def test_score_style_range_1_5():
+def test_score_style_should_scale_when_range_1_5():
     # range_size = 4; thresholds: green >= 1+3.2=4.2, yellow >= 1+2.4=3.4, orange >= 1+1.6=2.6
     assert _score_style(5, (1, 5)) == "bold green"
     assert _score_style(4, (1, 5)) == "yellow"
@@ -45,7 +45,7 @@ def test_score_style_range_1_5():
     assert _score_style(1, (1, 5)) == "bold red"
 
 
-def test_score_style_range_1_20():
+def test_score_style_should_scale_when_range_1_20():
     # range_size = 19; thresholds: green >= 1+15.2=16.2, yellow >= 1+11.4=12.4, orange >= 1+7.6=8.6
     assert _score_style(17, (1, 20)) == "bold green"
     assert _score_style(13, (1, 20)) == "yellow"
@@ -85,7 +85,7 @@ def _make_summary(score_range: tuple[int, int], results: list[RunResult]) -> Run
     )
 
 
-def test_individual_results_table_shows_correct_score_max():
+def test_results_table_should_show_correct_score_max():
     buf = StringIO()
     test_console = Console(file=buf, highlight=False, markup=False)
 
@@ -99,7 +99,7 @@ def test_individual_results_table_shows_correct_score_max():
     assert "/10" not in output
 
 
-def test_individual_results_table_default_range_shows_10():
+def test_results_table_should_show_10_when_default_range():
     buf = StringIO()
     test_console = Console(file=buf, highlight=False, markup=False)
 

--- a/tests/test_create_experiment.py
+++ b/tests/test_create_experiment.py
@@ -40,7 +40,7 @@ def _write_config(tmp_path: Path, config: dict) -> Path:
 # --- parse_config tests ---
 
 
-def test_parse_config_valid(tmp_path):
+def test_parse_config_should_parse_when_valid(tmp_path):
     config_file = _write_config(tmp_path, VALID_CONFIG)
     spec = parse_config(config_file)
 
@@ -52,7 +52,7 @@ def test_parse_config_valid(tmp_path):
     assert spec.judge.model == "openai:gpt-4o"
 
 
-def test_parse_config_minimal(tmp_path):
+def test_parse_config_should_parse_when_minimal(tmp_path):
     minimal = {
         "name": "minimal",
         "models": ["openai:gpt-4o-mini"],
@@ -70,21 +70,21 @@ def test_parse_config_minimal(tmp_path):
     assert spec.hypothesis == ""  # default
 
 
-def test_parse_config_missing_name(tmp_path):
+def test_parse_config_should_raise_when_name_missing(tmp_path):
     config = {k: v for k, v in VALID_CONFIG.items() if k != "name"}
     config_file = _write_config(tmp_path, config)
     with pytest.raises(CreateExperimentError, match="Missing required keys.*name"):
         parse_config(config_file)
 
 
-def test_parse_config_missing_models(tmp_path):
+def test_parse_config_should_raise_when_models_missing(tmp_path):
     config = {k: v for k, v in VALID_CONFIG.items() if k != "models"}
     config_file = _write_config(tmp_path, config)
     with pytest.raises(CreateExperimentError, match="Missing required keys.*models"):
         parse_config(config_file)
 
 
-def test_parse_config_no_inputs_defaults_to_default(tmp_path):
+def test_parse_config_should_default_inputs_when_none_provided(tmp_path):
     config = {k: v for k, v in VALID_CONFIG.items() if k != "inputs"}
     config_file = _write_config(tmp_path, config)
     spec = parse_config(config_file)
@@ -92,7 +92,7 @@ def test_parse_config_no_inputs_defaults_to_default(tmp_path):
     assert spec.inputs[0]["id"] == "default"
 
 
-def test_parse_config_missing_variants(tmp_path):
+def test_parse_config_should_raise_when_variants_missing(tmp_path):
     config = {k: v for k, v in VALID_CONFIG.items() if k != "variants"}
     config_file = _write_config(tmp_path, config)
     with pytest.raises(CreateExperimentError, match="Missing required keys.*variants"):
@@ -102,7 +102,7 @@ def test_parse_config_missing_variants(tmp_path):
 # --- validate_spec tests ---
 
 
-def test_validate_model_format_invalid():
+def test_validate_should_raise_when_model_format_invalid():
     spec = ExperimentSpec(
         name="test",
         models=["gpt-4o-mini"],  # missing provider prefix
@@ -113,7 +113,7 @@ def test_validate_model_format_invalid():
         validate_spec(spec)
 
 
-def test_validate_jinja2_vars_match():
+def test_validate_should_pass_when_jinja2_vars_match():
     spec = ExperimentSpec(
         name="test",
         models=["openai:gpt-4o-mini"],
@@ -123,7 +123,7 @@ def test_validate_jinja2_vars_match():
     validate_spec(spec)  # should not raise
 
 
-def test_validate_jinja2_vars_mismatch():
+def test_validate_should_raise_when_jinja2_vars_mismatch():
     spec = ExperimentSpec(
         name="test",
         models=["openai:gpt-4o-mini"],
@@ -136,7 +136,7 @@ def test_validate_jinja2_vars_mismatch():
         validate_spec(spec)
 
 
-def test_validate_judge_rubric_missing_vars():
+def test_validate_should_raise_when_judge_rubric_missing_vars():
     spec = ExperimentSpec(
         name="test",
         models=["openai:gpt-4o-mini"],
@@ -148,7 +148,7 @@ def test_validate_judge_rubric_missing_vars():
         validate_spec(spec)
 
 
-def test_validate_hardcoded_prompt_skips_jinja2_check():
+def test_validate_should_skip_jinja2_check_when_prompt_hardcoded():
     spec = ExperimentSpec(
         name="test",
         models=["openai:gpt-4o-mini"],
@@ -171,14 +171,14 @@ def test_validate_hardcoded_prompt_skips_jinja2_check():
         ("UPPERCASE", "uppercase"),
     ],
 )
-def test_parse_config_slugifies_name(tmp_path, input_name, expected):
+def test_parse_config_should_slugify_name(tmp_path, input_name, expected):
     config = {**VALID_CONFIG, "name": input_name}
     config_file = _write_config(tmp_path, config)
     spec = parse_config(config_file)
     assert spec.name == expected
 
 
-def test_validate_spec_slugifies_name():
+def test_validate_should_slugify_name():
     spec = ExperimentSpec(
         name="My Experiment",
         models=["openai:gpt-4o-mini"],
@@ -192,7 +192,7 @@ def test_validate_spec_slugifies_name():
 # --- scaffolder tests ---
 
 
-def test_scaffold_creates_directory_structure(tmp_path):
+def test_scaffold_should_create_directory_structure(tmp_path):
     spec = ExperimentSpec(
         name="test-exp",
         models=["openai:gpt-4o-mini"],
@@ -210,7 +210,7 @@ def test_scaffold_creates_directory_structure(tmp_path):
     assert (result_path / "v1" / "prompt.md").exists()
 
 
-def test_scaffold_skips_inputs_yaml_for_hardcoded_prompts(tmp_path):
+def test_scaffold_should_skip_inputs_yaml_when_prompt_hardcoded(tmp_path):
     spec = ExperimentSpec(
         name="test-exp",
         models=["openai:gpt-4o-mini"],
@@ -228,7 +228,7 @@ def test_scaffold_skips_inputs_yaml_for_hardcoded_prompts(tmp_path):
     assert (result_path / "v1" / "prompt.md").exists()
 
 
-def test_scaffold_experiment_md_content(tmp_path):
+def test_scaffold_should_write_experiment_md_content(tmp_path):
     spec = ExperimentSpec(
         name="test-exp",
         description="A test experiment",
@@ -252,7 +252,7 @@ def test_scaffold_experiment_md_content(tmp_path):
     assert post["runs"] == 3
 
 
-def test_scaffold_existing_dir_error(tmp_path):
+def test_scaffold_should_raise_when_directory_exists(tmp_path):
     spec = ExperimentSpec(
         name="existing-exp",
         models=["openai:gpt-4o-mini"],
@@ -271,7 +271,7 @@ def test_scaffold_existing_dir_error(tmp_path):
 # --- system.md tests ---
 
 
-def test_scaffold_creates_system_md_when_present(tmp_path):
+def test_scaffold_should_create_system_md_when_present(tmp_path):
     spec = ExperimentSpec(
         name="test-exp",
         models=["openai:gpt-4o-mini"],
@@ -288,7 +288,7 @@ def test_scaffold_creates_system_md_when_present(tmp_path):
     assert (result_path / "v1" / "system.md").read_text() == "You are a comedian"
 
 
-def test_scaffold_skips_system_md_when_absent(tmp_path):
+def test_scaffold_should_not_create_system_md_when_absent(tmp_path):
     spec = ExperimentSpec(
         name="test-exp",
         models=["openai:gpt-4o-mini"],
@@ -302,7 +302,7 @@ def test_scaffold_skips_system_md_when_absent(tmp_path):
     assert not (result_path / "v1" / "system.md").exists()
 
 
-def test_loader_reads_system_md(tmp_path):
+def test_loader_should_read_system_md(tmp_path):
     spec = ExperimentSpec(
         name="sys-test",
         models=["openai:gpt-4o-mini"],
@@ -326,7 +326,7 @@ def test_loader_reads_system_md(tmp_path):
     assert "{{ text }}" in variant.prompt.content
 
 
-def test_loader_returns_none_system_when_no_file(tmp_path):
+def test_loader_should_return_none_system_when_no_file(tmp_path):
     spec = ExperimentSpec(
         name="no-sys-test",
         models=["openai:gpt-4o-mini"],
@@ -344,7 +344,7 @@ def test_loader_returns_none_system_when_no_file(tmp_path):
     assert variant.prompt.system_content is None
 
 
-def test_validate_system_template_vars(tmp_path):
+def test_validate_should_check_system_template_vars(tmp_path):
     spec = ExperimentSpec(
         name="test",
         models=["openai:gpt-4o-mini"],
@@ -362,7 +362,7 @@ def test_validate_system_template_vars(tmp_path):
         validate_spec(spec)
 
 
-def test_parse_config_with_system(tmp_path):
+def test_parse_config_should_parse_system_when_provided(tmp_path):
     config = {
         **VALID_CONFIG,
         "variants": {
@@ -377,7 +377,7 @@ def test_parse_config_with_system(tmp_path):
 # --- Round-trip integration test (KEY) ---
 
 
-def test_roundtrip_scaffold_then_load(tmp_path):
+def test_scaffold_should_roundtrip_with_loader(tmp_path):
     spec = ExperimentSpec(
         name="roundtrip-test",
         description="Testing round-trip",

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -40,7 +40,7 @@ def _create_experiment(
     return variant_dir
 
 
-def test_load_experiment_loads_config(loader: YamlConfigLoader):
+def test_load_experiment_should_load_config(loader: YamlConfigLoader):
     config = loader.load_experiment(SAMPLE_EXPERIMENT)
 
     assert config.name == "sample-experiment"
@@ -49,12 +49,14 @@ def test_load_experiment_loads_config(loader: YamlConfigLoader):
     assert "anthropic:claude-sonnet-4-20250514" in config.models
 
 
-def test_load_experiment_raises_when_no_file(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_experiment_should_raise_when_no_file(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     with pytest.raises(YamlConfigLoaderError, match="experiment.md not found"):
         loader.load_experiment(tmp_path)
 
 
-def test_load_experiment_raises_when_no_models(
+def test_load_experiment_should_raise_when_no_models(
     loader: YamlConfigLoader, tmp_path: Path
 ):
     (tmp_path / "experiment.md").write_text("---\nname: test\n---\n")
@@ -70,7 +72,7 @@ def test_load_experiment_raises_when_no_models(
         ("runs: 10\n", 10),
     ],
 )
-def test_load_experiment_runs(
+def test_load_experiment_should_parse_runs(
     loader: YamlConfigLoader, tmp_path: Path, yaml_value: str, expected: int
 ):
     (tmp_path / "experiment.md").write_text(
@@ -81,7 +83,7 @@ def test_load_experiment_runs(
     assert config.runs == expected
 
 
-def test_load_variant_loads_complete(loader: YamlConfigLoader):
+def test_load_variant_should_load_complete_config(loader: YamlConfigLoader):
     variant = loader.load_variant(SAMPLE_VARIANT)
 
     assert variant.experiment.name == "sample-experiment"
@@ -91,7 +93,7 @@ def test_load_variant_loads_complete(loader: YamlConfigLoader):
     assert "openai:gpt-4o" in variant.models
 
 
-def test_load_variant_reads_prompt(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_read_prompt(loader: YamlConfigLoader, tmp_path: Path):
     _create_experiment(tmp_path, prompt="Be a {{ role }} assistant")
 
     variant = loader.load_variant(tmp_path / "v1")
@@ -99,7 +101,9 @@ def test_load_variant_reads_prompt(loader: YamlConfigLoader, tmp_path: Path):
     assert "Be a {{ role }} assistant" in variant.prompt.content
 
 
-def test_load_variant_raises_when_no_prompt(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_raise_when_no_prompt(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     (tmp_path / "experiment.md").write_text(
         "---\nname: test\nmodels: [openai:gpt-4o]\n---\n"
     )
@@ -111,7 +115,9 @@ def test_load_variant_raises_when_no_prompt(loader: YamlConfigLoader, tmp_path: 
         loader.load_variant(variant_dir)
 
 
-def test_load_variant_raises_when_no_judge(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_raise_when_no_judge(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     (tmp_path / "experiment.md").write_text(
         "---\nname: test\nmodels: [openai:gpt-4o]\n---\n"
     )
@@ -130,7 +136,7 @@ def test_load_variant_raises_when_no_judge(loader: YamlConfigLoader, tmp_path: P
         (None, None),
     ],
 )
-def test_load_variant_system_md(
+def test_load_variant_should_read_system_md(
     loader: YamlConfigLoader, tmp_path: Path, system: str | None, expected: str | None
 ):
     _create_experiment(tmp_path, system=system)
@@ -140,7 +146,7 @@ def test_load_variant_system_md(
     assert variant.prompt.system_content == expected
 
 
-def test_load_variant_reads_inputs(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_read_inputs(loader: YamlConfigLoader, tmp_path: Path):
     _create_experiment(
         tmp_path,
         inputs="- id: greeting-1\n  message: Hello!\n- id: greeting-2\n  message: Hi!\n",
@@ -154,7 +160,7 @@ def test_load_variant_reads_inputs(loader: YamlConfigLoader, tmp_path: Path):
     assert variant.inputs[1].id == "greeting-2"
 
 
-def test_load_variant_defaults_inputs_when_missing(
+def test_load_variant_should_default_inputs_when_missing(
     loader: YamlConfigLoader, tmp_path: Path
 ):
     _create_experiment(tmp_path)
@@ -166,7 +172,7 @@ def test_load_variant_defaults_inputs_when_missing(
     assert variant.inputs[0].data == {}
 
 
-def test_load_variant_reads_input_runs_override(
+def test_load_variant_should_read_input_runs_override(
     loader: YamlConfigLoader, tmp_path: Path
 ):
     _create_experiment(
@@ -188,7 +194,7 @@ def test_load_variant_reads_input_runs_override(
         ("---\nmodel: openai:gpt-4o\nchain_of_thought: false\n---\nEvaluate.\n", False),
     ],
 )
-def test_load_variant_judge_chain_of_thought(
+def test_load_variant_should_parse_judge_chain_of_thought(
     loader: YamlConfigLoader, tmp_path: Path, judge_yaml: str, expected: bool
 ):
     _create_experiment(tmp_path, judge=judge_yaml)
@@ -198,7 +204,9 @@ def test_load_variant_judge_chain_of_thought(
     assert variant.judge.chain_of_thought is expected
 
 
-def test_load_variant_judge_single_model(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_parse_judge_single_model(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     _create_experiment(tmp_path)
 
     variant = loader.load_variant(tmp_path / "v1")
@@ -209,7 +217,9 @@ def test_load_variant_judge_single_model(loader: YamlConfigLoader, tmp_path: Pat
     assert variant.judge.judge_models == ["openai:gpt-4o"]
 
 
-def test_load_variant_judge_multi_model(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_variant_should_parse_judge_multi_model(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     _create_experiment(
         tmp_path,
         judge=(
@@ -241,7 +251,7 @@ def test_load_variant_judge_multi_model(loader: YamlConfigLoader, tmp_path: Path
         ("aggregation: median\n", "median"),
     ],
 )
-def test_load_variant_judge_aggregation(
+def test_load_variant_should_parse_judge_aggregation(
     loader: YamlConfigLoader, tmp_path: Path, aggregation_yaml: str, expected: str
 ):
     _create_experiment(
@@ -262,7 +272,7 @@ def test_load_variant_judge_aggregation(
     assert variant.judge.aggregation == expected
 
 
-def test_load_variant_judge_invalid_aggregation(
+def test_load_variant_should_raise_when_judge_aggregation_invalid(
     loader: YamlConfigLoader, tmp_path: Path
 ):
     _create_experiment(
@@ -282,7 +292,7 @@ def test_load_variant_judge_invalid_aggregation(
         ("max_concurrency: 1\n", 1),
     ],
 )
-def test_load_experiment_max_concurrency(
+def test_load_experiment_should_parse_max_concurrency(
     loader: YamlConfigLoader, tmp_path: Path, yaml_value: str, expected: int
 ):
     (tmp_path / "experiment.md").write_text(
@@ -293,7 +303,9 @@ def test_load_experiment_max_concurrency(
     assert config.max_concurrency == expected
 
 
-def test_load_experiment_key_refs(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_experiment_should_parse_key_refs(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     (tmp_path / "experiment.md").write_text(
         "---\nname: test\nmodels: [openai:gpt-4o]\n"
         "key_refs:\n  openai: MY_OPENAI_KEY\n  anthropic: MY_ANTHROPIC_KEY\n---\n"
@@ -307,7 +319,9 @@ def test_load_experiment_key_refs(loader: YamlConfigLoader, tmp_path: Path):
     }
 
 
-def test_load_experiment_key_refs_default(loader: YamlConfigLoader, tmp_path: Path):
+def test_load_experiment_should_default_key_refs_when_missing(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     (tmp_path / "experiment.md").write_text(
         "---\nname: test\nmodels: [openai:gpt-4o]\n---\n"
     )
@@ -325,7 +339,7 @@ def test_load_experiment_key_refs_default(loader: YamlConfigLoader, tmp_path: Pa
         "key_refs:\n  openai: 123\n",
     ],
 )
-def test_load_experiment_key_refs_invalid(
+def test_load_experiment_should_raise_when_key_refs_invalid(
     loader: YamlConfigLoader, tmp_path: Path, bad_key_refs: str
 ):
     (tmp_path / "experiment.md").write_text(
@@ -336,7 +350,7 @@ def test_load_experiment_key_refs_invalid(
         loader.load_experiment(tmp_path)
 
 
-def test_discover_variants_finds_all(loader: YamlConfigLoader):
+def test_discover_variants_should_find_all(loader: YamlConfigLoader):
     variants = loader.discover_variants(SAMPLE_EXPERIMENT)
 
     assert len(variants) == 2
@@ -345,7 +359,9 @@ def test_discover_variants_finds_all(loader: YamlConfigLoader):
     assert "v2" in variant_names
 
 
-def test_discover_variants_raises_when_none(loader: YamlConfigLoader, tmp_path: Path):
+def test_discover_variants_should_raise_when_none(
+    loader: YamlConfigLoader, tmp_path: Path
+):
     (tmp_path / "experiment.md").write_text(
         "---\nname: test\nmodels: [openai:gpt-4o]\n---\n"
     )

--- a/tests/test_multi_judge.py
+++ b/tests/test_multi_judge.py
@@ -4,7 +4,7 @@ from promptlab.application.evaluate_response import (
 )
 
 
-def test_single_judge_is_not_multi():
+def test_judge_config_should_not_be_multi_when_single_model():
     result = JudgeResult(
         score=8,
         reasoning="Good response",
@@ -21,7 +21,7 @@ def test_single_judge_is_not_multi():
     assert result.is_multi_judge is False
 
 
-def test_multiple_judges_is_multi():
+def test_judge_config_should_be_multi_when_multiple_models():
     result = JudgeResult(
         score=8,
         reasoning="Combined reasoning",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -48,7 +48,7 @@ class _DummyProvider(Provider):
         ("anthropic:claude-sonnet-4-20250514", "anthropic", "claude-sonnet-4-20250514"),
     ],
 )
-def test_parse_model_id_valid(
+def test_parse_model_id_should_split_provider_and_model(
     model_id: str, expected_provider: str, expected_model: str
 ):
     provider, model = parse_model_id(model_id)
@@ -57,17 +57,17 @@ def test_parse_model_id_valid(
     assert model == expected_model
 
 
-def test_parse_model_id_raises_for_invalid():
+def test_parse_model_id_should_raise_when_invalid_format():
     with pytest.raises(ValueError, match="Invalid model ID"):
         parse_model_id("gpt-4o")
 
 
-def test_get_provider_raises_for_unknown():
+def test_get_provider_should_raise_when_unknown():
     with pytest.raises(ValueError, match="Unknown provider"):
         get_provider("unknown")
 
 
-def test_provider_response_default_values():
+def test_provider_response_should_have_default_values():
     response = ProviderResponse(content="Hello")
 
     assert response.content == "Hello"
@@ -77,7 +77,7 @@ def test_provider_response_default_values():
     assert response.latency_ms == 0
 
 
-def test_provider_response_with_tool_calls():
+def test_provider_response_should_include_tool_calls():
     tool_call = ToolCall(name="search", arguments={"query": "test"})
     response = ProviderResponse(
         content="Result",
@@ -88,7 +88,7 @@ def test_provider_response_with_tool_calls():
     assert response.tool_calls[0].name == "search"
 
 
-def test_provider_format_prompt_with_variables():
+def test_format_prompt_should_render_variables():
     provider = _DummyProvider()
     result = provider.format_prompt(
         "Hello {{ name }}, you are {{ age }}",
@@ -98,14 +98,14 @@ def test_provider_format_prompt_with_variables():
     assert result == "Hello Alice, you are 30"
 
 
-def test_provider_format_prompt_raises_for_missing():
+def test_format_prompt_should_raise_when_variable_missing():
     provider = _DummyProvider()
 
     with pytest.raises(ValueError, match="Missing input variable"):
         provider.format_prompt("Hello {{ name }}", {})
 
 
-def test_build_messages_without_system():
+def test_build_messages_should_exclude_system_when_not_provided():
     provider = _DummyProvider()
     system, user = provider.build_messages("Hello {{ name }}", {"name": "Alice"})
 
@@ -113,7 +113,7 @@ def test_build_messages_without_system():
     assert user == "Hello Alice"
 
 
-def test_build_messages_with_system():
+def test_build_messages_should_include_system_when_provided():
     provider = _DummyProvider()
     system, user = provider.build_messages(
         "Translate: {{ text }}",
@@ -125,7 +125,7 @@ def test_build_messages_with_system():
     assert user == "Translate: hello"
 
 
-def test_build_messages_hardcoded_no_vars():
+def test_build_messages_should_work_when_no_variables():
     provider = _DummyProvider()
     system, user = provider.build_messages("Tell me a joke", {})
 
@@ -137,7 +137,7 @@ def test_build_messages_hardcoded_no_vars():
 
 
 @patch("promptlab.infrastructure.providers.openai.AsyncOpenAI")
-def test_openai_provider_custom_env_var(
+def test_openai_provider_should_use_custom_env_var(
     mock_openai_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("MY_OPENAI_KEY", "test-key-123")
@@ -149,7 +149,7 @@ def test_openai_provider_custom_env_var(
 
 
 @patch("promptlab.infrastructure.providers.anthropic.AsyncAnthropic")
-def test_anthropic_provider_custom_env_var(
+def test_anthropic_provider_should_use_custom_env_var(
     mock_anthropic_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("MY_ANTHROPIC_KEY", "test-key-456")
@@ -161,7 +161,7 @@ def test_anthropic_provider_custom_env_var(
 
 
 @patch("promptlab.infrastructure.providers.openai.AsyncOpenAI")
-def test_openai_provider_default_env_var(
+def test_openai_provider_should_use_default_env_var(
     mock_openai_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("OPENAI_API_KEY", "default-key-123")
@@ -173,7 +173,7 @@ def test_openai_provider_default_env_var(
 
 
 @patch("promptlab.infrastructure.providers.anthropic.AsyncAnthropic")
-def test_anthropic_provider_default_env_var(
+def test_anthropic_provider_should_use_default_env_var(
     mock_anthropic_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "default-key-456")
@@ -184,7 +184,9 @@ def test_anthropic_provider_default_env_var(
     mock_anthropic_client.assert_called_once_with(api_key="default-key-456")
 
 
-def test_provider_custom_env_var_missing(monkeypatch: pytest.MonkeyPatch):
+def test_provider_should_raise_when_custom_env_var_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.delenv("MY_CUSTOM_KEY", raising=False)
 
     with pytest.raises(ValueError, match="MY_CUSTOM_KEY environment variable not set"):
@@ -192,7 +194,7 @@ def test_provider_custom_env_var_missing(monkeypatch: pytest.MonkeyPatch):
 
 
 @patch("promptlab.infrastructure.providers.openai.AsyncOpenAI")
-def test_get_provider_forwards_api_key_env_var(
+def test_get_provider_should_forward_api_key_env_var(
     mock_openai_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("MY_KEY", "forwarded-key-789")
@@ -204,7 +206,7 @@ def test_get_provider_forwards_api_key_env_var(
 
 
 @patch("promptlab.infrastructure.providers.openai.AsyncOpenAI")
-def test_get_provider_no_env_var_uses_default(
+def test_get_provider_should_use_default_when_no_env_var(
     mock_openai_client: MagicMock, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.setenv("OPENAI_API_KEY", "default-factory-key")
@@ -215,7 +217,7 @@ def test_get_provider_no_env_var_uses_default(
     mock_openai_client.assert_called_once_with(api_key="default-factory-key")
 
 
-def test_experiment_config_key_refs_default():
+def test_experiment_config_should_have_empty_key_refs_when_default():
     config = ExperimentConfig(
         name="test-experiment",
         description="Test description",
@@ -226,7 +228,7 @@ def test_experiment_config_key_refs_default():
     assert isinstance(config.key_refs, dict)
 
 
-def test_key_refs_merge_cli_overrides_config():
+def test_key_refs_should_override_config_when_cli_provided():
     """CLI key_refs take precedence over experiment.md key_refs."""
     config_refs = {"openai": "CONFIG_OPENAI_KEY", "anthropic": "CONFIG_ANTHROPIC_KEY"}
     cli_refs = {"openai": "CLI_OPENAI_KEY"}
@@ -240,20 +242,20 @@ def test_key_refs_merge_cli_overrides_config():
 # --- known_providers ---
 
 
-def test_known_providers_returns_frozenset():
+def test_known_providers_should_return_frozenset():
     result = known_providers()
 
     assert isinstance(result, frozenset)
 
 
-def test_known_providers_contains_registered():
+def test_known_providers_should_contain_registered():
     result = known_providers()
 
     assert "openai" in result
     assert "anthropic" in result
 
 
-def test_known_providers_excludes_unknown():
+def test_known_providers_should_not_contain_unknown():
     result = known_providers()
 
     assert "unknown" not in result

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -6,7 +6,7 @@ from promptlab.domain.statistics import (
 )
 
 
-def test_calculate_stats_single_run():
+def test_calculate_stats_should_compute_when_single_run():
     results = [
         RunResult(
             input_id="test-1",
@@ -36,7 +36,7 @@ def test_calculate_stats_single_run():
     assert stats[0].ci_upper == 8.0
 
 
-def test_calculate_stats_multiple_runs():
+def test_calculate_stats_should_compute_when_multiple_runs():
     results = [
         RunResult(
             input_id="test-1",
@@ -88,7 +88,7 @@ def test_calculate_stats_multiple_runs():
     assert stats[0].ci_upper > stats[0].mean
 
 
-def test_calculate_stats_groups_by_input_and_model():
+def test_calculate_stats_should_group_by_input_and_model():
     results = [
         RunResult(
             input_id="test-1",
@@ -139,13 +139,13 @@ def test_calculate_stats_groups_by_input_and_model():
     assert stats_dict[("test-2", "openai:gpt-4o")].mean == 7.0
 
 
-def test_confidence_interval_single_sample():
+def test_confidence_interval_should_return_none_when_single_sample():
     ci_lower, ci_upper = calculate_confidence_interval(8.0, 0.0, 1)
     assert ci_lower == 8.0
     assert ci_upper == 8.0
 
 
-def test_confidence_interval_multiple_samples():
+def test_confidence_interval_should_compute_when_multiple_samples():
     # mean=9, stddev=1, n=3
     # t_crit for df=2 is 4.303
     # margin = 4.303 * (1 / sqrt(3)) = 4.303 * 0.577 = 2.48
@@ -156,7 +156,7 @@ def test_confidence_interval_multiple_samples():
     assert 11.0 < ci_upper < 12.0  # ~11.48
 
 
-def test_welch_t_test_same_distributions():
+def test_welch_t_test_should_not_be_significant_when_same_distributions():
     scores1 = [8, 9, 8, 9, 8]
     scores2 = [8, 9, 8, 9, 8]
     t_stat, p_value = welch_t_test(scores1, scores2)
@@ -164,7 +164,7 @@ def test_welch_t_test_same_distributions():
     assert p_value == 1.0
 
 
-def test_welch_t_test_different_distributions():
+def test_welch_t_test_should_be_significant_when_different_distributions():
     scores1 = [9, 10, 9, 10, 9]  # mean ~9.4
     scores2 = [5, 6, 5, 6, 5]  # mean ~5.4
     t_stat, p_value = welch_t_test(scores1, scores2)
@@ -172,7 +172,7 @@ def test_welch_t_test_different_distributions():
     assert p_value <= 0.05
 
 
-def test_welch_t_test_insufficient_samples():
+def test_welch_t_test_should_return_none_when_insufficient_samples():
     scores1 = [8]
     scores2 = [9]
     t_stat, p_value = welch_t_test(scores1, scores2)


### PR DESCRIPTION
## Summary

- Rename all 98 test functions across 8 files to follow `test_<subject>_should[_not]_<expectation>[_when_<scenario>]`
- No logic, fixtures, imports, or assertions changed — only function names

## Test plan

- [x] All 114 tests pass